### PR TITLE
[WAPI-1789] Add NFT summary query for total infused and estimated floor

### DIFF
--- a/src/server-extension/accounts-nft-summary.ts
+++ b/src/server-extension/accounts-nft-summary.ts
@@ -43,9 +43,7 @@ export class AccountsNftSummaryResolver {
     constructor(private tx: () => Promise<EntityManager>) {}
 
     @Query(() => AccountsNftSummaryResponse)
-    async accountsNftSummary(
-        @Args() { accountIds }: AccountsNftSummaryArgs
-    ): Promise<AccountsNftSummaryResponse> {
+    async accountsNftSummary(@Args() { accountIds }: AccountsNftSummaryArgs): Promise<AccountsNftSummaryResponse> {
         const manager = await this.tx()
 
         // Get total infused amount

--- a/src/server-extension/accounts-nft-summary.ts
+++ b/src/server-extension/accounts-nft-summary.ts
@@ -1,0 +1,92 @@
+import { Field, ObjectType, Query, Resolver, Args, ArgsType } from 'type-graphql'
+import { BigInteger } from '@subsquid/graphql-server'
+import 'reflect-metadata'
+import type { EntityManager } from 'typeorm'
+import { Validate, ValidatorConstraint, ValidatorConstraintInterface } from 'class-validator'
+import { TokenAccount, Token, Collection } from '../model'
+import { isValidAddress } from '../util/tools'
+
+@ValidatorConstraint({ name: 'PublicKeyArray', async: false })
+export class IsPublicKeyArray implements ValidatorConstraintInterface {
+    validate(value: string[]) {
+        if (!Array.isArray(value)) return false
+        return value.every((address) => isValidAddress(address))
+    }
+
+    defaultMessage() {
+        return 'One or more invalid public keys in the array!'
+    }
+}
+
+@ArgsType()
+class AccountsNftSummaryArgs {
+    @Field(() => [String])
+    @Validate(IsPublicKeyArray)
+    accountIds!: string[]
+}
+
+@ObjectType()
+export class AccountsNftSummaryResponse {
+    @Field(() => BigInteger)
+    totalInfused!: typeof BigInteger
+
+    @Field(() => BigInteger)
+    estimatedTotalFloor!: typeof BigInteger
+
+    constructor(props: Partial<AccountsNftSummaryResponse>) {
+        Object.assign(this, props)
+    }
+}
+
+@Resolver()
+export class AccountsNftSummaryResolver {
+    constructor(private tx: () => Promise<EntityManager>) {}
+
+    @Query(() => AccountsNftSummaryResponse)
+    async accountsNftSummary(
+        @Args() { accountIds }: AccountsNftSummaryArgs
+    ): Promise<AccountsNftSummaryResponse> {
+        const manager = await this.tx()
+
+        // Get total infused amount
+        const infusedResult = await manager
+            .getRepository(TokenAccount)
+            .createQueryBuilder('token_account')
+            .innerJoin(Token, 'token', 'token_account.token = token.id')
+            .select('SUM(token.infusion * token_account.balance)', 'totalInfused')
+            .where('token_account.account IN (:...accountIds)', { accountIds })
+            .getRawOne()
+
+        const totalInfused = BigInt(infusedResult?.totalInfused || 0)
+
+        // Get estimated total floor value
+        // First, get the sum of balances per collection for the given accounts
+        const collectionBalances = await manager
+            .getRepository(TokenAccount)
+            .createQueryBuilder('token_account')
+            .innerJoin(Token, 'token', 'token_account.token = token.id')
+            .innerJoin(Collection, 'collection', 'token.collection = collection.id')
+            .select('collection.id', 'collectionId')
+            .addSelect("collection.stats->>'floorPrice'", 'floorPrice')
+            .addSelect('SUM(token_account.balance)', 'totalBalance')
+            .where('token_account.account IN (:...accountIds)', { accountIds })
+            .groupBy('collection.id')
+            .addGroupBy("collection.stats->>'floorPrice'")
+            .getRawMany()
+
+        // Calculate estimated total floor
+        let estimatedTotalFloor = 0n
+        for (const row of collectionBalances) {
+            if (row.floorPrice) {
+                const floorPrice = BigInt(row.floorPrice)
+                const balance = BigInt(row.totalBalance)
+                estimatedTotalFloor += floorPrice * balance
+            }
+        }
+
+        return new AccountsNftSummaryResponse({
+            totalInfused: totalInfused as any,
+            estimatedTotalFloor: estimatedTotalFloor as any,
+        })
+    }
+}

--- a/src/server-extension/resolvers/index.ts
+++ b/src/server-extension/resolvers/index.ts
@@ -14,6 +14,7 @@ import { TokenListingsResolver } from '../token-listings'
 import { SyncBalancesResolver } from '../sync-balances'
 import { SyncMetadataResolver } from '../sync-metadata'
 import { AccountsTokensResolver } from '../accounts-tokens'
+import { AccountsNftSummaryResolver } from '../accounts-nft-summary'
 import { SyncOffersResolver } from '../sync-offers'
 import { ValidatorDetailsResolver } from '../validator-details'
 import { RefreshPoolResolver } from '../refresh-pool'
@@ -35,6 +36,7 @@ export {
     SyncBalancesResolver,
     SyncMetadataResolver,
     AccountsTokensResolver,
+    AccountsNftSummaryResolver,
     SyncOffersResolver,
     ValidatorDetailsResolver,
 }


### PR DESCRIPTION
## Summary
Added a new GraphQL query `accountsNftSummary` that returns aggregated NFT data for multiple accounts:
- Total infused ENJ amount across all tokens
- Estimated total floor value based on collection floor prices

## Changes
- Created new resolver `AccountsNftSummaryResolver` in `src/server-extension/accounts-nft-summary.ts`
- Added efficient database queries using TypeORM query builder with proper joins and aggregations
- Registered the new resolver in the server extensions

## Technical Details
- Query accepts an array of account IDs with validation
- Returns two aggregated values:
  - `totalInfused`: Sum of (token.infusion × tokenAccount.balance) for all tokens
  - `estimatedTotalFloor`: Sum of (collection.floorPrice × total balance per collection)
- Optimized queries to minimize database load