### PR TITLE
[WAPI-1789] Fix balance field to include reserved tokens

### DIFF
--- a/src/server-extension/accounts-nft-summary.ts
+++ b/src/server-extension/accounts-nft-summary.ts
@@ -51,7 +51,7 @@ export class AccountsNftSummaryResolver {
             .getRepository(TokenAccount)
             .createQueryBuilder('token_account')
             .innerJoin(Token, 'token', 'token_account.token = token.id')
-            .select('SUM(token.infusion * token_account.balance)', 'totalInfused')
+            .select('SUM(token.infusion * token_account.totalBalance)', 'totalInfused')
             .where('token_account.account IN (:...accountIds)', { accountIds })
             .getRawOne()
 


### PR DESCRIPTION
## Summary
Fixed the accounts NFT summary query to use `totalBalance` instead of `balance` to include reserved tokens in the infusion calculation.

## Changes
- Updated `AccountsNftSummaryResolver` to use `token_account.totalBalance` instead of `token_account.balance`
- This ensures reserved tokens are included in the total infused calculation

## Technical Details
The change affects the SQL query in the `totalInfused` calculation, switching from the `balance` field to `totalBalance` field in the token_account table. This provides a more accurate representation of token holdings by including reserved amounts.